### PR TITLE
Remove email from deploy script

### DIFF
--- a/bin/deploy
+++ b/bin/deploy
@@ -22,7 +22,7 @@ function retry() {
 }
 
 echo "Logging into Docker hub"
-retry 3 docker login -e="$DOCKER_EMAIL" -u="$DOCKER_USER" -p="$DOCKER_PASS"
+retry 3 docker login -u="$DOCKER_USER" -p="$DOCKER_PASS"
 
 echo "Tagging app:build with $CIRCLE_TAG"
 docker tag app:build "$DOCKERHUB_REPO:$CIRCLE_TAG" ||


### PR DESCRIPTION
Newer versions of docker do not require email address as part of `docker login`