### PR TITLE
Added an enforcement that results are limited to 4 items

### DIFF
--- a/taar_api/app.py
+++ b/taar_api/app.py
@@ -7,6 +7,8 @@ from dockerflow.flask import Dockerflow
 
 from taar_lite.recommenders import GuidBasedRecommender
 from srgutil.context import default_context
+from taar_api.context import Logging, IMozLogging
+
 import json
 from decouple import config
 import optparse
@@ -16,7 +18,7 @@ dockerflow = Dockerflow(app)
 
 VALID_BRANCHES = set(['linear', 'ensemble', 'control'])
 
-TAAR_MAX_RESULTS = config('TAAR_MAX_RESULTS', default=10, cast=int)
+TAAR_MAX_RESULTS = config('TAAR_MAX_RESULTS', default=4, cast=int)
 
 
 class ResourceProxy(object):
@@ -42,8 +44,12 @@ def recommendations(guid):
     if PROXY_MANAGER.getResource() is None:
         ctx = default_context()
 
+        # Install logging
+        ctx[IMozLogging] = Logging(ctx)
+
         # Lock the context down after we've got basic bits installed
         root_ctx = ctx.child()
+
         instance = GuidBasedRecommender(root_ctx)
         PROXY_MANAGER.setResource(instance)
 
@@ -51,6 +57,10 @@ def recommendations(guid):
     cdict = {'guid': guid}
     recommendations = instance.recommend(client_data=cdict,
                                          limit=TAAR_MAX_RESULTS)
+
+    if len(recommendations) != TAAR_MAX_RESULTS:
+        recommendations = []
+
     # Strip out weights from TAAR results to maintain compatibility
     # with TAAR 1.0
     jdata = {"results": [x[0] for x in recommendations]}

--- a/taar_api/app.py
+++ b/taar_api/app.py
@@ -7,7 +7,6 @@ from dockerflow.flask import Dockerflow
 
 from taar_lite.recommenders import GuidBasedRecommender
 from srgutil.context import default_context
-from taar_api.context import Logging, IMozLogging
 
 import json
 from decouple import config
@@ -43,9 +42,6 @@ def recommendations(guid):
 
     if PROXY_MANAGER.getResource() is None:
         ctx = default_context()
-
-        # Install logging
-        ctx[IMozLogging] = Logging(ctx)
 
         # Lock the context down after we've got basic bits installed
         root_ctx = ctx.child()

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -1,7 +1,13 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import json
 from flask import url_for
-from taar_api.app import app as flask_app
 import pytest
 import uuid
+
+from taar_api.app import app as flask_app
 
 
 @pytest.fixture
@@ -14,10 +20,41 @@ class EmptyRecommendationManager:
         return []
 
 
+class NormalRecommendationManager:
+    def recommend(self, client_data, limit):
+        return [("some_guid", 20),
+                ("another_guid", 10),
+                ("another_guid1", 5),
+                ("another_guid2", 1)]
+
+
+class ShortRecommendationManager:
+    def recommend(self, client_data, limit):
+        return [("some_guid", 2), ("another_guid", 1)]
+
+
 @pytest.fixture
 def empty_recommendation_manager(monkeypatch):
     monkeypatch.setattr('taar_api.app.PROXY_MANAGER._resource',
                         EmptyRecommendationManager())
+
+
+@pytest.fixture
+def normal_recommendation_manager(monkeypatch):
+    """ A recommendation manager that only returns 2 results (less
+    than MAX of 4)
+    """
+    monkeypatch.setattr('taar_api.app.PROXY_MANAGER._resource',
+                        NormalRecommendationManager())
+
+
+@pytest.fixture
+def short_recommendation_manager(monkeypatch):
+    """ A recommendation manager that only returns 2 results (less
+    than MAX of 4)
+    """
+    monkeypatch.setattr('taar_api.app.PROXY_MANAGER._resource',
+                        ShortRecommendationManager())
 
 
 def test_minimal_request(client, empty_recommendation_manager):
@@ -25,3 +62,21 @@ def test_minimal_request(client, empty_recommendation_manager):
     assert response.status_code == 200
     assert response.headers['Content-Type'] == 'application/json'
     assert response.data == b'{"results": []}'
+
+
+def test_short_request_limit(client, short_recommendation_manager):
+    """Recommendations that return less than the max number of results
+    should truncate the result list to the empty list.
+    """
+    response = client.get(url_for('recommendations', guid=uuid.uuid4()))
+    assert response.status_code == 200
+    assert response.headers['Content-Type'] == 'application/json'
+    assert response.data == b'{"results": []}'
+
+
+def test_normal_request_limit(client, normal_recommendation_manager):
+    response = client.get(url_for('recommendations', guid=uuid.uuid4()))
+    assert response.status_code == 200
+    assert response.headers['Content-Type'] == 'application/json'
+    results = json.loads(response.data.decode('utf8'))['results']
+    assert len(results) == 4


### PR DESCRIPTION
Recommendations should either return 4 results or 0 results.

This PR includes code and tests to change TAAR_MAX_RESULTS to 4 and verify that the final resultset is always length 4 or 0. 